### PR TITLE
Reference correct files in Dockerfile

### DIFF
--- a/tools/khakis/ui-server/Dockerfile
+++ b/tools/khakis/ui-server/Dockerfile
@@ -9,8 +9,8 @@ RUN mkdir /usr/share/nginx/html/.well-known
 
 COPY default.conf /etc/nginx/conf.d/default.conf
 ADD  build/html/build /usr/share/nginx/html/build
-ADD  build/html/build/src /usr/share/nginx/html/src
-ADD  build/html/build/production.html /usr/share/nginx/html/index.html
+ADD  build/html/build/dist/src /usr/share/nginx/html/src
+ADD  build/html/build/dist/production.html /usr/share/nginx/html/index.html
 
 
 CMD [ "/usr/bin/run-nginx" ]


### PR DESCRIPTION
This solves a problem where the distDocker target fails because the "src" directory and production.html cant be copied into the docker image.