### PR TITLE
Remove import of now deleted promon components

### DIFF
--- a/src/components/settings/places/update-service-level/update-service-level.stache
+++ b/src/components/settings/places/update-service-level/update-service-level.stache
@@ -16,8 +16,6 @@ limitations under the License.
 
 <can-import from="i2web/components/form/billing/" />
 <can-import from="i2web/components/settings/places/update-service-level/premium-to-basic.component" />
-<can-import from="i2web/components/settings/places/update-service-level/promon-to-basic.component" />
-<can-import from="i2web/components/settings/places/update-service-level/promon-to-premium.component" />
 <can-import from="i2web/components/settings/places/update-service-level/upgrade.component" />
 
 {{#switch activeDisplay}}


### PR DESCRIPTION
This fixes a critical issue that breaks the production build (see #2 for the error report)

cc @KevinTsang 