### PR TITLE
Set a few common security headers

### DIFF
--- a/tools/khakis/ui-server/default.conf
+++ b/tools/khakis/ui-server/default.conf
@@ -8,6 +8,9 @@ server {
     add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, CONNECT';
     add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Client-Version';
     add_header 'Access-Control-Max-Age' 1728000;
+    add_header 'X-Frame-Options' 'SAMEORIGIN';
+    add_header 'X-Content-Type-Options' 'nosniff';
+    add_header 'Referrer-Policy' 'same-origin';
 
     # Configuration JSON files are never cached
     if ($request_filename ~* \.(?:json)$ ) {


### PR DESCRIPTION
This pull request sets a few common security headers to improve the overall security posture of arcus web:

* X-Frame-Options: prevents malicious sites from framing the arcus ui and tricking a user into performing an operation, like unlocking a door.
* X-Content-Type-Options: prevents content type confusion from sniffing the content type from item contents
* Referrer-Policy: avoids leaking information that the user is using Arcus if they click links from the Arcus UI to a third-party site.

In a future revision the CORS policy should probably be removed since it doesn't appear to be needed (it should only be set by the client-bridge, not the UI), and CSP should be added to better mitigate against XSS. Both of these changes will need additional testing, and thus are deferred to another revision.