### PR TITLE
Add alarms.json to config (fixes firefox for real this time #5)

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -20,6 +20,8 @@ import developmentConfig from 'config/development.json';
 import productionConfig from 'config/production.json';
 import serverConfig from 'config/server.json';
 import alarmConfig from 'config/alarms.json';
+import careConfig from 'config/care-behaviors.json';
+import relationshipsConfig from 'config/relationships.json';
 import subsystemConfig from 'config/subsystem.json';
 import ruleCategoriesConfig from 'config/rule-categories.json';
 

--- a/src/config.js
+++ b/src/config.js
@@ -19,6 +19,7 @@ import appMeta from 'package.json';
 import developmentConfig from 'config/development.json';
 import productionConfig from 'config/production.json';
 import serverConfig from 'config/server.json';
+import alarmConfig from 'config/alarms.json';
 import subsystemConfig from 'config/subsystem.json';
 import ruleCategoriesConfig from 'config/rule-categories.json';
 


### PR DESCRIPTION
This fixes an issue where arcus isn't able to load alarms.json which apparently breaks firefox.