### PR TITLE
Restore commit "Removed missing icons"

### DIFF
--- a/src/components/catalog/selectable/selectable.stache
+++ b/src/components/catalog/selectable/selectable.stache
@@ -19,9 +19,7 @@ limitations under the License.
 
 <div class="selectable-container {{containerClasses}}" ($click)="onSelect()">
   <div class="logo-container">
-    {{#if brandLogoURL}}
-      <img src="{{brandLogoURL}}" title="{{thingName}}"/>
-    {{/if}}
+    <span>{{thingName}}</span>
   </div>
 
   <div class="main-container">


### PR DESCRIPTION
This was inadvertently included in https://github.com/arcus-smart-home/arcusweb/pull/12 in addition to #11  and reverted as part of that pull request, so the fix landed in #11 and got reverted in #12.