### PR TITLE
Create build/dist/config folder

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -82,7 +82,7 @@ app.use(vhost(host, staticApp));
 if (nconf.get('NODE_ENV') === 'production') {
   const configDestDir = `${ROOT}/build/dist/config`;
   if (!fs.existsSync(configDestDir)) {
-    fs.mkdirSync(configDestDir);
+    fs.mkdirSync(configDestDir, {'recursive': true});
   }
   fs.writeFileSync(`${configDestDir}/server.json`, fs.readFileSync(`${ROOT}/config/server.json`));
 }


### PR DESCRIPTION
This should remove the need to have the following troubleshooting instructions in the README:

"If you run into problems with npm run start, you may need to create a couple folders:

mkdir build
cd build
mkdir dist
cd ..
npm run start"