### PR TITLE
Add cache busting

### DIFF
--- a/production.html
+++ b/production.html
@@ -26,6 +26,6 @@ limitations under the License.
   <link rel="mask-icon" href="/src/images/favicons/safari-pinned-tab.svg" color="#3e205e">
 </head>
 <body>
-  <script src="/build/dist/steal.production.js"></script>
+  <script src="/build/dist/steal.production.js" cache-version="preprod-version"></script>
 </body>
 </html>

--- a/tools/khakis/build.gradle
+++ b/tools/khakis/build.gradle
@@ -28,6 +28,16 @@ task "copyDist-ui"(type: Copy) {
   into "ui-server/build/html"
 }
 
+task "cacheBust-ui"(type: Task) {
+  dependsOn "copyDist-ui"
+  doLast {
+    def productionFile = file("ui-server/build/html/build/dist/production.html")
+    def text = productionFile.text
+    text = text.replaceAll("preprod-version", "${dockerVersion}")
+    productionFile.write(text)
+  }
+}
+
 task startService(type: Task) {
 }
 
@@ -84,6 +94,7 @@ task distDocker(type: Task) {
 servers.each { server ->
   task "distDocker-${server.id}"(type: Exec) {
     dependsOn "copyDist-${server.id}"
+    dependsOn "cacheBust-${server.id}"
 
     def List<String> cLine = new ArrayList<String>()
     cLine.add('docker');


### PR DESCRIPTION
Add a task to the distDocker target that bumps the cache-version for each release, thus invalidating the user's browser cache on page reload.