### PR TITLE
Remove security questions on invite page

### DIFF
--- a/src/pages/invite/invite.stache
+++ b/src/pages/invite/invite.stache
@@ -64,10 +64,6 @@ limitations under the License.
         {place}="place"
         {session}="session"
       />
-      <arcus-create-account-step-security-questions invited
-        {completed-stages}="completedStages"
-        {person}="person"
-      />
       <arcus-create-account-step-pin invited
         {completed-stages}="completedStages"
         {person}="person"


### PR DESCRIPTION
Invited users shouldn't have to fill this out either