### PR TITLE
Fix hub online since

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The first time, add a host entry for:
 
 Then create a certificate:
 `openssl genrsa -out bin/localhost.key 2048`
-`openssl req -new -x509 -key localhost.key -out localhost.cert -days 3650 -subj /CN=localdev.arcussmarthome.com`
+`openssl req -new -x509 -key bin/localhost.key -out bin/localhost.cert -days 3650 -subj /CN=localdev.arcussmarthome.com`
 
 Development mode can be started with:
 

--- a/src/components/hub/configurators/connectivity-power.component
+++ b/src/components/hub/configurators/connectivity-power.component
@@ -111,7 +111,7 @@ limitations under the License.
             if (hub && hub.attr('hubconn:lastchange')) {
               const lastChange = moment(hub.attr('hubconn:lastchange'));
               const duration = moment.duration(moment().diff(lastChange));
-              return `${lastChange.format('MMM DD, YYYY h:mm A')} (${duration.days()} d, ${duration.days()} hrs, ${duration.minutes()} mins)`;
+              return `${lastChange.format('MMM DD, YYYY h:mm A')} (${duration.days()} d, ${duration.hours()} hrs, ${duration.minutes()} mins)`;
             }
             return '-';
           },


### PR DESCRIPTION
The "Online Since" field in Hub details was showing the number of days of uptime under "Hours", likely due to a copy/paste error.