### PR TITLE
Add illuminance badge

### DIFF
--- a/config/device.js
+++ b/config/device.js
@@ -56,6 +56,9 @@ export const capabilityPlugins = {
     },
     configurators: ['brightness'],
   },
+  'ill:illuminance': {
+    badges: ['illuminance'],
+  },
   'light:colormode': {
     configurators() {
       const color = this.hasCapability('color');

--- a/src/components/device/badges/badges.js
+++ b/src/components/device/badges/badges.js
@@ -22,6 +22,7 @@ import './gpm.component';
 import './heatingState.component';
 import './hotWaterLevel.component';
 import './humidity.component';
+import './illuminance.component';
 import './leaf.component';
 import './lockState.component';
 import './lowHeatTarget.component';
@@ -157,6 +158,16 @@ import './waterHeaterEnergySmart.component';
  * @parent i2web/components/device/badges
  * @description The humidity component
  * @signature `<arcus-device-badge-humidity>`
+ *
+ */
+
+  // ---------------- ILLUMINANCE DOCUMENTATION -------------------//
+
+/**
+ * @module {canComponent} i2web/components/device/badges/illuminance Illuminance
+ * @parent i2web/components/device/badges
+ * @description illuminance humidity component
+ * @signature `<arcus-device-badge-illuminance>`
  *
  */
 

--- a/src/components/device/badges/illuminance.component
+++ b/src/components/device/badges/illuminance.component
@@ -1,0 +1,34 @@
+<!--
+Copyright 2020 Arcus Project
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<can-component tag="arcus-device-badge-illuminance">
+  <template>
+    <span class="device-status-detail"><i class="icon-app-sun-1"></i>&nbsp;{{device['ill:illuminance']}} Lux</span>
+  </template>
+  <script type="view-model">
+    import canMap from 'can-map';
+    import 'can-map-define';
+    import Device from 'i2web/models/device';
+
+    export default canMap.extend({
+      define: {
+        device: {
+          Type: Device,
+        },
+      },
+    });
+  </script>
+</can-component>


### PR DESCRIPTION
Add a badge to show illuminance, needed for the Aeotec MultiSensor 6.