### PR TITLE
Allow battery percent to be shown via config

### DIFF
--- a/src/components/device/badges/powerSource.component
+++ b/src/components/device/badges/powerSource.component
@@ -35,6 +35,7 @@ limitations under the License.
   <script type="view-model">
     import canMap from 'can-map';
     import 'can-map-define';
+    import config from 'i2web/config';
     import Device from 'i2web/models/device';
 
     export default canMap.extend({
@@ -51,6 +52,7 @@ limitations under the License.
         showNumericPercentage: {
           get() {
             return (
+              !!parseInt(config.enableBatteryPercentage, 10) ||
               this.attr('isSwannCamera') ||
               this.attr('device.devpow:batteryLow')
             );

--- a/tools/khakis/ui-server/run-nginx
+++ b/tools/khakis/ui-server/run-nginx
@@ -17,7 +17,8 @@ echo "   \"wsUrl\"  : \"$ARCUS_WS_URI\","    >> $SERVER_CONF
 echo "   \"iosDownloadUrl\"  : \"$ARCUS_IOS_DOWNLOAD_URI\","    >> $SERVER_CONF
 echo "   \"androidDownloadUrl\"  : \"$ARCUS_ANDROID_DOWNLOAD_URI\","    >> $SERVER_CONF
 echo "   \"enableYearlySubscription\"  : $ARCUS_ENABLE_YEARLY_SUBSCRIPTION,"    >> $SERVER_CONF
-echo "   \"enableHubWifiScan\"  : $ARCUS_ENABLE_HUB_WIFI_SCAN"    >> $SERVER_CONF
+echo "   \"enableHubWifiScan\"  : $ARCUS_ENABLE_HUB_WIFI_SCAN,"    >> $SERVER_CONF
+echo "   \"enableBatteryPercentage\"  : $ARCUS_ENABLE_BATTERY_PERCENTAGE"    >> $SERVER_CONF
 echo "}" >> $SERVER_CONF
 
 nginx -g 'daemon off;'


### PR DESCRIPTION
Allow an Arcus operator to configure whether the battery percentage should be visible.