### PR TITLE
Distinguish network failures from auth failures

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -971,6 +971,7 @@ const AppViewModel = canMap.extend({
     auth.on('authentication:fail', this.authFail.bind(this));
     auth.on('authentication:success', this.authSuccess.bind(this));
     auth.on('authentication:logout', this.authLogout.bind(this));
+    auth.on('connection:lost', this.connectionLost.bind(this));
     auth.authenticate().then(() => {
       this.attr('loginMethod', 'auto');
     }).catch(e => canDev.warn(e));
@@ -1001,24 +1002,28 @@ const AppViewModel = canMap.extend({
     this.attr('reconnecting', false);
   },
   /**
+  * @function connectionLost
+  * @parent i2web/app
+  *
+  * Handles temporary network disconnects while user is authenticated.
+  * Cornea handles reconnection via backoff — we just show a notification.
+  */
+  connectionLost() {
+    if (!this.attr('reconnecting')) {
+      this.attr('reconnecting', true);
+      Notifications.error('Lost connection to Arcus. Reconnecting...', 'icon-app-light-1');
+    }
+  },
+  /**
   * @function authFail
   * @parent i2web/app
   *
-  * if authorization fails, if they were logged in, it is reconnection and an error message will
-  * display, otherwise, they will be redirected to login
+  * If authorization fails (not authenticated and connection failed),
+  * redirect to login.
   */
   authFail() {
     this.attr('authenticating', false);
-    // If user was logged in, this is a reconnection
-    // Show an error. When the reconnection happens, authSuccess will redirect.
-    // If user is fresh, go to login.
-    if (this.attr('loggedIn')) {
-      this.attr('reconnecting', true);
-      // This is just a temporary solution until there is a proper error notification widget.
-      Notifications.error('Lost connection to Arcus. Reconnecting...', 'icon-app-light-1');
-    } else {
-      this.redirectToLogin();
-    }
+    this.redirectToLogin();
   },
   /**
   * @function authLogout

--- a/src/models/auth.js
+++ b/src/models/auth.js
@@ -204,8 +204,12 @@ class Auth extends events.EventEmitter {
       // if a user was authenticated but their session was killed (account deleted?),
       // they will be logged out elsewhere, but we don't want to trigger an auth:fail in this case
       this.cleanupCornea();
+    } else if (this.authenticated) {
+      // network failure while authenticated — Cornea handles reconnection,
+      // don't reset auth state since the session is still valid
+      this.emit('connection:lost');
     } else {
-      // closed for any other reason
+      // not authenticated and connection failed — real auth failure
       this.emit('authentication:fail');
     }
   }

--- a/src/pages/login/login.js
+++ b/src/pages/login/login.js
@@ -258,9 +258,15 @@ export const ViewModel = FormViewModel.extend({
       this.removeAttr('sessionError');
       this.attr('logInUser')(this.attr('emailAddress'), this.attr('password'), this.attr('isPublic')).then(() => {
         getAppState().attr('logoutRequested', false);
-      }).catch(() => {
+      }).catch((e) => {
         this.attr('saving', false);
-        this.attr('formError', 'Invalid username or password');
+        if (e && e.status === 0) {
+          this.attr('formError', 'Unable to reach the server. Please check your connection and try again.');
+        } else if (e && e.status >= 500) {
+          this.attr('formError', 'A server error occurred. Please try again later.');
+        } else {
+          this.attr('formError', 'Invalid username or password');
+        }
       });
     }
   },


### PR DESCRIPTION
Network disconnects while authenticated no longer emit authentication:fail, which was resetting auth state and could flood duplicate notifications. A new connection:lost event handles reconnection UI instead. Login page now shows distinct messages for server errors vs bad credentials.